### PR TITLE
Add Claude 3 Opus model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Streamlit Frontend for Amazon Bedrock
 
-| 🚧 Under heavy construction 🚧
-
 ## Usage
 
 ### Launch

--- a/main.py
+++ b/main.py
@@ -37,13 +37,15 @@ with st.sidebar:
         options=(
             'Claude 3 Haiku',
             'Claude 3 Sonnet',
+            'Claude 3 Opus',
             ),
         index=1,
-        help="There a 3 model variants in the Claude 3 family: Haiku, Sonnet, and Opus (Not available yet). Visit the [official Blog Post](https://www.anthropic.com/news/claude-3-family) for more information."
+        help="There a 3 model variants in the Claude 3 family: Haiku, Sonnet, and Opus. Visit the [official Blog Post](https://www.anthropic.com/news/claude-3-family) for more information."
         )
     claude_3_model_hashmap = {
         'Claude 3 Haiku': 'anthropic.claude-3-haiku-20240307-v1:0',
         'Claude 3 Sonnet': 'anthropic.claude-3-sonnet-20240229-v1:0',
+        'Claude 3 Opus': 'anthropic.claude-3-opus-20240229-v1:0'
         }
     st.session_state['claude_3_model_id'] = claude_3_model_hashmap[claude_3_model_name]
     

--- a/poetry.lock
+++ b/poetry.lock
@@ -1417,4 +1417,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "9560b90518a7e57de6402e5f6c23d51b20b31812e44081e9d10ccf29b26eced0"
+content-hash = "703d18516a1a9de734beb2bc159c999f7d6ccc9ecbd2fd02ff0ce50db2ae6471"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ pandas = "^2.2.1"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "^8.22.2"
+watchdog = "^4.0.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Claude 3 Opus is [available on AWS](https://aws.amazon.com/bedrock/claude/), though only in [`us-west-2`](https://docs.aws.amazon.com/bedrock/latest/userguide/models-regions.html)